### PR TITLE
add footer

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -14,6 +14,9 @@
 		<h2>userland projects</h2>
 		<Projects_Table projects={userland_projects} />
 	</section>
+	<footer>
+		<a href="https://github.com/feltcoop/grogarden.org">github.com/feltcoop/grogarden.org</a>
+	</footer>
 </main>
 
 <style>
@@ -44,6 +47,10 @@
 		font-weight: 300;
 		line-height: 1.1;
 		margin: 20px auto;
+	}
+
+	footer {
+		margin-bottom: 40px;
 	}
 
 	@media (min-width: 480px) {


### PR DESCRIPTION
Adds a simple footer with a link back to this repo. We'll probably create a standard footer using the current felt.social one as a guide and import from Felt, but that can wait.